### PR TITLE
Composite MBeans support

### DIFF
--- a/riemann-jmx.yaml.example
+++ b/riemann-jmx.yaml.example
@@ -61,3 +61,14 @@ queries :
     -   TotalBytesWritten
     -   TotalFetchRequestMs
     -   TotalProduceRequestMs
+
+-  service : "java.lang:type=Memory"
+   obj     : "java.lang:type=Memory"
+   attr    : 
+    - HeapMemoryUsage.used
+    - HeapMemoryUsage.max
+    - HeapMemoryUsage.init
+    - NonHeapMemoryUsage.used
+    - NonHeapMemoryUsage.max 
+    - NonHeapMemoryUsage.init
+    

--- a/src/riemann_jmx_clj/core.clj
+++ b/src/riemann_jmx_clj/core.clj
@@ -24,10 +24,10 @@
   (let [{:keys [jmx queries]} yaml]
     (->> (jmx/with-connection jmx
            (doall
-             (for [{:keys [obj attr tags]} queries
+             (for [{:keys [obj attr tags service]} queries
                    name (jmx/mbean-names obj)
                    attr attr ]
-               {:service (str (.getCanonicalName ^javax.management.ObjectName name) \. attr)
+               {:service (if service (str service \. attr) (str (.getCanonicalName ^javax.management.ObjectName name) \. attr))
                 :host (if (:event_host jmx)
                         (:event_host jmx)
                         (:host jmx))


### PR DESCRIPTION
Hello,

I've tried to implement composite MBeans support using a `dot` notation.

There must be a way to avoid multiple `(str/split attr #"\.")` call. Fix me please.
