### PR TITLE
always sleep on connection failure

### DIFF
--- a/src/riemann_jmx_clj/core.clj
+++ b/src/riemann_jmx_clj/core.clj
@@ -78,10 +78,10 @@
     (future
       (while true
         (try
-          (run-configuration munged)
-          (Thread/sleep (* 1000 (-> yaml :riemann :interval)))
+          (run-configuration munged)   
           (catch Exception e
-            (.printStackTrace e)))))))
+            (.printStackTrace e))
+          (finally (Thread/sleep (* 1000 (-> yaml :riemann :interval)))))))))
 
 (defn -main
   [& args]


### PR DESCRIPTION
if an exception occurs in run-configuration the sleep is never evaluated
resulting in heavy cpu load; e.g., on connection failure to the riemann
server.

Thanks to @lucianjon for finding this bug and @moonranger for the solution. 
