### PR TITLE
Using service yaml value as source for the Riemann event service value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+*.swp

--- a/riemann-jmx.yaml.example
+++ b/riemann-jmx.yaml.example
@@ -37,6 +37,19 @@ jmx :
     password : superSECRETpass
 
 queries :
+    # If service is set, its value will be used to set Riemann Event service (RES) field. 
+    # Otherwise, the RES value will be set to the value of the obj field, which is the full JMX object name. 
+    # This might be important in cases when using special characters (comma, collon, space, quotes, etc) in service names 
+    # creates issues with querying such metrics. One notable example is Graphite, that uses host.service.attr as a metric path, and 
+    # Grafana that has difficulties querrying metrics paths with special characters in the service field.
+    #
+    # Examples: service set to "kafka.broker.topics.all" 
+    #               => Riemann Event{:host "localhost-9999" :service "kafka.broker.topics.alli.BytesIn" ...} 
+    #               => Graphite "localhost-9999.kafka.broker.topics.all.BytesIn"
+    #
+    #           service not set,
+    #               => Riemann Event{:host "localhost-9999" :service "kafka:type=kafka.LogFlushStats" ...}
+    #               => Graphite "localhost-9999.kafka:type=kafka.LogFlushStats.AvgFlushMs"
 -   service     : "kafka.broker.topics.all"
     obj         : "kafka:type=kafka.BrokerAllTopicStat"
     attr        : [ BytesIn, BytesOut, FailedFetchRequest, FailedProduceRequest, MessagesIn ]

--- a/src/riemann_jmx_clj/core.clj
+++ b/src/riemann_jmx_clj/core.clj
@@ -24,10 +24,12 @@
   (let [{:keys [jmx queries]} yaml]
     (->> (jmx/with-connection jmx
            (doall
-             (for [{:keys [obj attr tags]} queries
+             (for [{:keys [obj attr tags service]} queries
                    name (jmx/mbean-names obj)
                    attr attr]
-               {:service (str (.getCanonicalName ^javax.management.ObjectName name) \. attr)
+               {:service (if service 
+                            (str service \. attr)
+                            (str (.getCanonicalName ^javax.management.ObjectName name) \. attr))
                 :host (if (:event_host jmx)
                         (:event_host jmx)
                         (or (:host jmx) (.getCanonicalHostName (InetAddress/getLocalHost))))


### PR DESCRIPTION
I would like to be able to set an arbitrary name for the service setting to avoid some issues originating in special characters used for JMX object names, like commas, white spaces etc

In my case I am using the following pipe for collecting JMX metrics
riemann-jmx -> riemann -> cyanite (Graphite in Clojure)

Visualizations are created with Grafana, which has issues to query metrics if service values are created from object names.

Example, a yaml fragment: 
queries :
-   service     : "hbase.region.server"
  use_service : true
  obj         : "Hadoop:name=RegionServer,service=HBase,sub=Server"

With use_service set to false, or no, the path of a metric stored by Cyanite looks like this
  my_event_host.Hadoop:name=RegionServer,service=HBase,sub=Server.regionCount

with use_service set to true or yes, the metric path becomes
  my_event_host.hbase.region.server.regionCount

which is easier to handle when quering metrics from tools like Grafana. 
