### PR TITLE
Upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/twosigma/riemann-jmx"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/java.jmx "0.2.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/java.jmx "0.3.3"]
                  [clj-yaml "0.4.0"]
-                 [riemann-clojure-client "0.2.6"]]
+                 [riemann-clojure-client "0.4.4"]]
   :main riemann-jmx-clj.core)

--- a/src/riemann_jmx_clj/core.clj
+++ b/src/riemann_jmx_clj/core.clj
@@ -51,9 +51,9 @@
                (get-riemann-connection host port)
                (get-riemann-connection host))
         events (run-queries yaml)]
-    @(riemann/send-events conn events)
-    (prn (format "Sent %s events to riemann" (count events)))))
-
+    (print ".")
+    (flush)
+    (riemann/send-events conn events)))
 
 (defn munge-credentials
   "Takes a parsed yaml config and, if it has jmx username & password,


### PR DESCRIPTION
Not sure if anyone still uses this but it was the best method I could find for extracting server metrics from java apps like zookeeper which don't provide the ability to plugin a custom metrics reporter. If there's anything better around, I'd be interested to learn of it.

I also have a branch that adds a Dockerfile to make building it easy to build a docker container that runs this program. Can make a separate PR for that if you're interested.

/cc @dgrnbrg (whose open source contributions I appear to be stalking but it's just a coincidence I promise)